### PR TITLE
Updating git cloning method for public repositories

### DIFF
--- a/docsite/source/config_autodeploy_node.rst
+++ b/docsite/source/config_autodeploy_node.rst
@@ -82,25 +82,7 @@ Environment variables for Red Hat Subscription credentials should be defined:
     export RHN_PASS="password" # escape dollar signs (\\$)
     export RHN_POOL="pool_id" # 32-char pool ID
 
-Next, an ssh key file should be created for GitHub access. Put the text for a
-private key which has access to the GitHub repositories in the lines below:
-
-.. code-block:: bash
-
-    cat << EOF > ~/github.pem
-    -----BEGIN RSA PRIVATE KEY-----
-    <insert_key_file_text_here>
-    -----END RSA PRIVATE KEY-----
-    EOF
-
-Change the file permissions to ensure security.
-
-.. code-block:: bash
-
-    chmod 0600 ~/github.pem
-
-With the environment variables defined and the ssh key file created, the build
-script can be launched:
+With the environment variables defined, the build script can be launched:
 
 .. code-block:: bash
 
@@ -194,29 +176,11 @@ play from the :code:`dcaf` Git repository.
 
     wget https://raw.githubusercontent.com/csc/dcaf/master/modules/autodeploynode/initial_stage.yml
 
-In order to download the projects from GitHub, a keyfile must be created. Put the
-text for a private key which has access to the GitHub repositories in the lines
-below:
+Now the initial_stage.yml playbook can be run, as shown below:
 
 .. code-block:: bash
 
-    cat << EOF > ~/github.pem
-    -----BEGIN RSA PRIVATE KEY-----
-    <insert_key_file_text_here>
-    -----END RSA PRIVATE KEY-----
-    EOF
-
-Change the file permissions to ensure security.
-
-.. code-block:: bash
-
-    chmod 0600 ~/github.pem
-
-Now the initial\_stage.yml playbook can be run, as shown below:
-
-.. code-block:: bash
-
-    ansible-playbook initial_stage.yml --extra-vars "github_key_file=~/github.pem"
+    ansible-playbook initial_stage.yml
 
 Now that the DCAF project has been retrieved it can be used to install the remaining
 support packages. Change into the DCAF project directory.
@@ -237,7 +201,6 @@ following variables in the :code:`inventory/group_vars/all.yml` file.
     # Required User Variables
     rhn_user:
     rhn_pass:
-    github_key_file: (location of the github.pem file created above)
 
 Run the stage_resources.yml play:
 

--- a/docsite/source/offline_autodeploy_node.rst
+++ b/docsite/source/offline_autodeploy_node.rst
@@ -64,25 +64,7 @@ Set the environment variables for Red Hat Subscription Manage credentials:
     export RHN_PASS="password"    # escape dollar signs (\$)
     export RHN_POOL="pool_id"     # 32-char pool ID
 
-Create a ssh key file for GitHub access.  Put the text for a private key which
-has access to the GitHub repositories in the lines below:
-
-.. code-block:: bash
-
-    cat << EOF > ~/github.pem
-    -----BEGIN RSA PRIVATE KEY-----
-    <insert_key_file_text_here>
-    -----END RSA PRIVATE KEY-----
-    EOF
-
-Change the file permissions to ensure security.
-
-.. code-block:: bash
-
-    chmod 0600 ~/github.pem
-
-With the environment variables defined and the ssh key file created, the build
-script can be launched:
+With the environment variables defined, the build script can be launched:
 ​
 
 .. code-block:: bash

--- a/docsite/source/quickstart.rst
+++ b/docsite/source/quickstart.rst
@@ -30,7 +30,6 @@ User Access Requirements
 To retrieve the automation resources from their online repositories you will
 need the following:
 
-- A valid github.com user account with access to the CSC Git repositories.
 - A Red Hat user account with a valid subscription associated with it.
 
 Network Requirements
@@ -96,7 +95,6 @@ and configures the AutoDeployNode. Review the script for more details of all the
 steps which are performed.
 
 Set the environment variables for Red Hat Subscription Manage credentials:
-​
 
 .. code-block:: bash
 
@@ -104,26 +102,7 @@ Set the environment variables for Red Hat Subscription Manage credentials:
     export RHN_PASS="password"    # escape dollar signs (\$)
     export RHN_POOL="pool_id"     # 32-char pool ID
 
-Create a ssh key file for GitHub access.  Put the text for a private key which
-has access to the GitHub repositories in the lines below:
-
-.. code-block:: bash
-
-    cat << EOF > ~/github.pem
-    -----BEGIN RSA PRIVATE KEY-----
-    <insert_key_file_text_here>
-    -----END RSA PRIVATE KEY-----
-    EOF
-
-Change the file permissions to ensure security.
-
-.. code-block:: bash
-
-    chmod 0600 ~/github.pem
-
-With the environment variables defined and the ssh key file created, the build
-script can be launched:
-​
+With the environment variables defined, the build script can be launched:
 
 .. code-block:: bash
 

--- a/modules/autodeploynode/ansible.cfg
+++ b/modules/autodeploynode/ansible.cfg
@@ -1,0 +1,5 @@
+# Local Ansible Configuration File
+[defaults]
+hostfile = ./inventory/hosts.ini
+host_key_checking = False
+log_path = ~/ansible.log

--- a/modules/autodeploynode/build.sh
+++ b/modules/autodeploynode/build.sh
@@ -7,14 +7,6 @@
 # export RHN_PASS="password"    # escape dollar signs (\$)
 # export RHN_POOL="pool_id"     # 32-char pool ID
 
-# Additionally, a pem file should be created to provide access to private GitHub repos
-# cat << EOF > ~/github.pem
-# -----BEGIN RSA PRIVATE KEY-----
-# <insert_key_file_text_here>
-# -----END RSA PRIVATE KEY-----
-# EOF
-# chmod 0600 ~/github.pem
-
 # Once these prerequisites are in place, the script can be executed by:
 # curl https://raw.githubusercontent.com/csc/dcaf/master/modules/autodeploynode/build.sh | bash
 
@@ -38,8 +30,8 @@ yum -y --nogpgcheck localinstall ./rpm-build/ansible-*.noarch.rpm
 cd ..
 
 wget https://raw.githubusercontent.com/csc/dcaf/master/modules/autodeploynode/initial_stage.yml
-ansible-playbook initial_stage.yml --extra-vars "github_key_file=~/github.pem"
+ansible-playbook initial_stage.yml
 cd /opt/autodeploy/projects/dcaf/modules/autodeploynode
 
-ansible-playbook stage_resources.yml --extra-vars "github_key_file=~/github.pem rhn_user=$RHN_USER rhn_pass=$RHN_PASS"
-ansible-playbook main.yml --extra-vars "github_key_file=~/github.pem"
+ansible-playbook stage_resources.yml --extra-vars "rhn_user=$RHN_USER rhn_pass=$RHN_PASS"
+ansible-playbook main.yml

--- a/modules/autodeploynode/initial_stage.yml
+++ b/modules/autodeploynode/initial_stage.yml
@@ -14,7 +14,7 @@
     resources_base_path: "{{ autodeploy_base_path }}/resources"
 
     git_repos:
-      - { name: "dcaf", repo: "git@github.com:csc/dcaf.git" }
+      - { name: "dcaf", repo: "https://github.com/csc/dcaf.git" }
 
   tasks:
 
@@ -30,8 +30,6 @@
       git:
         repo: "{{ item.repo }}"
         dest: "{{ projects_base_path }}/{{ item.name }}"
-        accept_hostkey: yes
-        key_file: "{{ github_key_file }}"
       with_items: "{{ git_repos }}"
 
     - name: Checkout the latest tagged version

--- a/modules/autodeploynode/inventory/group_vars/all.yml
+++ b/modules/autodeploynode/inventory/group_vars/all.yml
@@ -2,7 +2,6 @@
 # Required User Variables
 rhn_user:
 rhn_pass:
-github_key_file:
 
 # Offline autodeploy vars
 offline: false
@@ -30,7 +29,7 @@ hnl_rhel_min_image: rhel-server-7.2-x86_64-dvd-hnl.iso
 hnl_mk_source: https://github.com/csc/Hanlon-Microkernel/releases/download/v2.0.1/
 hnl_mk_local_path: /opt/hanlon/image/
 hnl_mk_path: /home/hanlon/image/{{ hnl_mk_image }}
-kvm_guest_image: rhel-guest-image-7.2-20160219.1.x86_64.qcow2
+kvm_guest_image: rhel-guest-image-7.2-20160301.0.x86_64.qcow2
 rhel_iso_image: rhel-server-7.2-x86_64-dvd.iso
 
 # Offline Staging vars
@@ -39,8 +38,8 @@ scaleio_source_zip: ScaleIO_1.32.2_Linux_SW_Download.zip
 scaleio_source_url: "http://downloads.emc.com/emc-com/usa/ScaleIO/{{scaleio_source_zip}}"
 
 git_repos:
-  - { name: "slimer", repo: "git@github.com:csc/slimer.git" }
-  - { name: "ansible-scaleio", repo: "git@github.com:csc/ansible-scaleio.git" }
+  - { name: "slimer", repo: "https://github.com/csc/slimer.git" }
+  - { name: "ansible-scaleio", repo: "https://github.com/csc/ansible-scaleio.git" }
 
 # Offline usb staging vars
 usb_projects_path: "{{ usb_hdd }}/autodeploy/projects"

--- a/modules/autodeploynode/roles/base/tasks/main.yml
+++ b/modules/autodeploynode/roles/base/tasks/main.yml
@@ -98,8 +98,6 @@
   git:
     repo: "{{ item.repo }}"
     dest: "{{ projects_base_path }}/{{ item.name }}"
-    accept_hostkey: yes
-    key_file: "{{ github_key_file }}"
   with_items: "{{ git_repos }}"
   ignore_errors: true
   when: not offline

--- a/modules/autodeploynode/stage_resources.yml
+++ b/modules/autodeploynode/stage_resources.yml
@@ -44,8 +44,6 @@
       git:
         repo: "{{ item.repo }}"
         dest: "{{ projects_base_path }}/{{ item.name }}"
-        accept_hostkey: yes
-        key_file: "{{ github_key_file }}"
       with_items: "{{ git_repos }}"
       ignore_errors: true
 


### PR DESCRIPTION
All public repos:
* git clone operations using non-ssh URLs
* ssh private key file no longer required

Others:
* ansible.cfg added for specifiying the inventory before the
  default ansible.cfg file is updated
* Version bump for RHEL KVM Guest Image

Testing:
```
[root@rhel72 autodeploynode]# ansible-playbook stage_resources.yml --extra-vars "rhn_user=$RHN_USER rhn_pass=$RHN_PASS"

...

PLAY RECAP *********************************************************************
localhost                  : ok=19   changed=6    unreachable=0    failed=0
```

```
[root@rhel72 autodeploynode]# ansible-playbook main.yml

...

PLAY RECAP *********************************************************************
localhost                  : ok=51   changed=37   unreachable=0    failed=0
```
