### PR TITLE
remove hardcoded dev names from ovs role

### DIFF
--- a/modules/kvm-host/roles/ovs/tasks/main.yml
+++ b/modules/kvm-host/roles/ovs/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 # Backup ifcfg file
-- name: Backing up ifcfg file for em3
-  shell: cp /etc/sysconfig/network-scripts/ifcfg-em3 /etc/sysconfig/network-scripts/orig-ifcfg-em3
+- name: Backing up ifcfg file for mgmt_nic
+  shell: cp /etc/sysconfig/network-scripts/ifcfg-{{mgmt_nic}} /etc/sysconfig/network-scripts/orig-ifcfg-{{mgmt_nic}}
   tags:
     - mgmt_bridge
 
 # Copy ifcfg-em3 file to br0
 - name: Convert ifcfg file for bridge config
-  shell: mv /etc/sysconfig/network-scripts/ifcfg-em3 /etc/sysconfig/network-scripts/ifcfg-br0
+  shell: mv /etc/sysconfig/network-scripts/ifcfg-{{mgmt_nic}} /etc/sysconfig/network-scripts/ifcfg-br0
   tags:
     - mgmt_bridge
 
@@ -29,15 +29,15 @@
 
 
 # Copy over purged ifcfg-em3 file
-- name: Copy ifcfg file for em3
+- name: Copy ifcfg file for mgmt_nic
   template:
     src: ifcfg-em3.j2
-    dest: /etc/sysconfig/network-scripts/ifcfg-em3
+    dest: /etc/sysconfig/network-scripts/ifcfg-{{mgmt_nic}}
   tags:
     - mgmt_bridge
 
 - name: Restart interfaces 
-  shell: ifdown em3 ; ifup em3 ; ifup br0
+  shell: ifdown {{mgmt_nic}} ; ifup {{mgmt_nic}} ; ifup br0
   tags:
     - mgmt_bridge
 
@@ -48,11 +48,11 @@
   register: iplink_output
   failed_when: "'does not exist' in iplink_output.stderr"
 
-- name: Backup all bond0.180* files
+- name: Backup all bond vlan files
   shell: 'cp /etc/sysconfig/network-scripts/ifcfg-{{ item.port }} /etc/sysconfig/network-scripts/orig-ifcfg-{{ item.port }}'
   with_items: '{{ ovs_bridges }}'
 
-- name: update all bond0 vlans files
+- name: update all bond vlans files
   template: 
     src: ifcfg-bond.j2
     dest: /etc/sysconfig/network-scripts/ifcfg-{{item.port}}


### PR DESCRIPTION
OVS role running.
```
2016-03-24 16:24:27,516 p=16952 u=root |  TASK [ovs : Backing up ifcfg file for mgmt_nic] ********************************
2016-03-24 16:24:27,622 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-2]^[[0m
2016-03-24 16:24:27,655 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-3]^[[0m
2016-03-24 16:24:27,694 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-1]^[[0m
2016-03-24 16:24:27,696 p=16952 u=root |  TASK [ovs : Convert ifcfg file for bridge config] ******************************
2016-03-24 16:24:27,825 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-2]^[[0m
2016-03-24 16:24:27,833 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-3]^[[0m
2016-03-24 16:24:27,892 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-1]^[[0m
2016-03-24 16:24:27,895 p=16952 u=root |  TASK [ovs : Change device name in ifcfg file] **********************************
2016-03-24 16:24:27,980 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-2]^[[0m
2016-03-24 16:24:27,984 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-3]^[[0m
2016-03-24 16:24:28,046 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-1]^[[0m
2016-03-24 16:24:28,049 p=16952 u=root |  TASK [ovs : remove HW address from ifcfg-br0] **********************************
2016-03-24 16:24:28,133 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-2]^[[0m
2016-03-24 16:24:28,137 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-3]^[[0m
2016-03-24 16:24:28,198 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-1]^[[0m
2016-03-24 16:24:28,201 p=16952 u=root |  TASK [ovs : Copy ifcfg file for mgmt_nic] **************************************
2016-03-24 16:24:28,374 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-2]^[[0m
2016-03-24 16:24:28,375 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-3]^[[0m
2016-03-24 16:24:28,469 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-1]^[[0m
2016-03-24 16:24:28,472 p=16952 u=root |  TASK [ovs : Restart interfaces] ************************************************
2016-03-24 16:24:32,465 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-3]^[[0m
2016-03-24 16:24:32,687 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-2]^[[0m
2016-03-24 16:24:33,502 p=16952 u=root |  ^[[0;33mchanged: [kvm_controller-1]^[[0m
```
Final recap
```
PLAY RECAP *********************************************************************
auto-deploy-node           : ok=10   changed=3    unreachable=0    failed=0
basevm                     : ok=8    changed=6    unreachable=0    failed=0
controller-1               : ok=7    changed=6    unreachable=0    failed=0
controller-2               : ok=7    changed=6    unreachable=0    failed=0
controller-3               : ok=7    changed=6    unreachable=0    failed=0
haproxy-1                  : ok=7    changed=6    unreachable=0    failed=0
haproxy-2                  : ok=7    changed=6    unreachable=0    failed=0
kvm_controller-1           : ok=44   changed=27   unreachable=0    failed=0
kvm_controller-2           : ok=31   changed=20   unreachable=0    failed=0
kvm_controller-3           : ok=31   changed=20   unreachable=0    failed=0
network-1                  : ok=7    changed=6    unreachable=0    failed=0
network-2                  : ok=7    changed=6    unreachable=0    failed=0
network-3                  : ok=7    changed=6    unreachable=0    failed=0
swift-1                    : ok=7    changed=6    unreachable=0    failed=0
swift-2                    : ok=7    changed=6    unreachable=0    failed=0
swift-3                    : ok=7    changed=6    unreachable=0    failed=0
```