### PR TITLE
autodeployneode - inventory dir

### DIFF
--- a/modules/autodeploynode/roles/base/tasks/main.yml
+++ b/modules/autodeploynode/roles/base/tasks/main.yml
@@ -23,6 +23,15 @@
   when: offline
   with_fileglob: "../../files/*pip-requirements*"
 
+- name: Create the inventory directories
+  file:
+    path: "{{ projects_base_path }}/{{ item }}"
+    state: directory
+  with_items:
+    - inventory
+    - inventory/host_vars
+    - inventory/group_vars
+
 - name: Create the .ssh directory
   file:
     path: /root/.ssh/


### PR DESCRIPTION
Create the inventory directories in the autodeploynode base role.

```
PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Create the inventory directories] **************************************
changed: [localhost] => (item=inventory)
changed: [localhost] => (item=inventory/host_vars)
changed: [localhost] => (item=inventory/group_vars)

PLAY RECAP ********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

[root@kragle ansible]# ls /opt/autodeploy/projects/inventory/
group_vars  host_vars
```