### PR TITLE
Removing version specification for RHEL KVM Guest Image

### DIFF
--- a/modules/autodeploynode/inventory/group_vars/all.yml
+++ b/modules/autodeploynode/inventory/group_vars/all.yml
@@ -29,7 +29,6 @@ hnl_rhel_min_image: rhel-server-7.2-x86_64-dvd-hnl.iso
 hnl_mk_source: https://github.com/csc/Hanlon-Microkernel/releases/download/v2.0.1/
 hnl_mk_local_path: /opt/hanlon/image/
 hnl_mk_path: /home/hanlon/image/{{ hnl_mk_image }}
-kvm_guest_image: rhel-guest-image-7.2-20160301.0.x86_64.qcow2
 rhel_iso_image: rhel-server-7.2-x86_64-dvd.iso
 
 # Offline Staging vars
@@ -71,12 +70,6 @@ autodeploy_support_pkgs:
 source_projects:
   - ansible-scaleio
   - slimer
-
-iso_files:
-  - "{{ hnl_mk_image }}"
-  - "{{ rhel_iso_image }}"
-  - "{{ hnl_rhel_min_image }}"
-  - "{{ kvm_guest_image }}"
 
 docker_images:
   - { name: hanlon-mongo, image: mongo, tar_file: mongo.tar }

--- a/modules/autodeploynode/stage_resources.yml
+++ b/modules/autodeploynode/stage_resources.yml
@@ -92,9 +92,10 @@
       when: not (rhel_iso.stat.exists)
       tags: iso
 
-    - name: Check if Red Hat KVM Guest image file exists in /opt/autodeploy/resources/ISO
-      stat:
-        path: "{{ iso_path }}/{{ kvm_guest_image }}"
+    - name: Check if Red Hat KVM Guest image file exists
+      find:
+        path: "{{ iso_path }}"
+        pattern: "rhel-guest-image*.qcow2"
       register: kvm_guest
       tags: iso
 
@@ -106,16 +107,16 @@
         password: "{{ rhn_pass }}"
         username_element_id: username
         password_element_id: password
-        xpath: '//*[contains(@href,"{{ kvm_guest_image }}")]'
+        xpath: '//*[contains(@href,"rhel-guest-image")]'
       register: kvm_get_url
-      when: not (kvm_guest.stat.exists)
+      when: kvm_guest.matched == 0
       tags: iso
 
     - name: Download the KVM Guest Image file to /opt/autodeploy/resources/ISO
       get_url:
         url: "{{ kvm_get_url.url }}"
         dest: "{{ iso_path }}"
-      when: not (kvm_guest.stat.exists)
+      when: kvm_guest.matched == 0
       tags: iso
 
     - name: Download the EPEL RPMs to /opt/autodeploy/resources/rpms when offline


### PR DESCRIPTION
This PR removes the need to specify a version of the RHEL KVM Guest Image for download.  This file is frequently updated on the Red Hat Downloads site.

The `iso_files` variable was removed because it is no longer needed with the removal of the `verify-files` role.

Testing (some task output deleted for brevity):
```
[root@rhel72 autodeploynode]# git checkout mtnbikenc/kvm-image
Previous HEAD position was 3bd2764... Merge pull request #4 from mtnbikenc/git-update
HEAD is now at 9bd8fc5... Removing version specification for RHEL KVM Guest Image
[root@rhel72 autodeploynode]# time ansible-playbook stage_resources.yml --extra-vars "rhn_user=$RHN_USER rhn_pass=$RHN_PASS"

PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

<snip>

TASK [Check if Red Hat KVM Guest image file exists] ****************************
ok: [localhost]

TASK [Find the Red Hat KVM Guest Image file url] *******************************
ok: [localhost]

TASK [Download the KVM Guest Image file to /opt/autodeploy/resources/ISO] ******
changed: [localhost]

<snip>

PLAY RECAP *********************************************************************
localhost                  : ok=21   changed=9    unreachable=0    failed=0

real	18m28.551s
user	3m14.140s
sys	1m55.016s
```