### PR TITLE
General updates during testing.

### DIFF
--- a/modules/kvm-host/site.yml
+++ b/modules/kvm-host/site.yml
@@ -54,7 +54,7 @@
   hosts: auto_deploy_node
   gather_facts: false
   tasks:
-   - name: wait for clones to come up
+   - name: wait for basevm to come up
      wait_for:
        host: '{{ basevm_static_ip }}'
        state: started
@@ -137,7 +137,7 @@
   hosts: auto_deploy_node
   gather_facts: false
   tasks:
-   - name: wait for clones to come up
+   - name: wait for clones to come up after creation
      wait_for: 
        host: "{{ hostvars[item]['ansible_ssh_host'] }}"
        state: started 
@@ -198,7 +198,7 @@
   hosts: auto_deploy_node
   gather_facts: false
   tasks:
-   - name: wait for clones to come up
+   - name: wait for clones to come up after hardware configuration 
      wait_for:
        host: "{{ hostvars[item]['ansible_ssh_host'] }}"
        state: started

--- a/modules/rhel-osp/roles/common/tasks/main.yml
+++ b/modules/rhel-osp/roles/common/tasks/main.yml
@@ -25,7 +25,7 @@
   lineinfile:
     dest: /etc/hosts 
     regexp: '.*{{ item }}$'
-    line: "{{ hostvars[item]['ansible_'+control_if.device]['ipv4']['address'] }} {{item}}"
+    line: "{{ hostvars[item]['ansible_'+hostvars[item]['control_if'].device]['ipv4']['address'] }} {{item}}"
     state: present
   with_items: "{{groups[group]}}"
 

--- a/modules/rhel-osp/roles/haproxy/templates/kilo.haproxy.cfg.j2
+++ b/modules/rhel-osp/roles/haproxy/templates/kilo.haproxy.cfg.j2
@@ -241,16 +241,18 @@ backend swift
   server {{ hostvars[node]['ansible_hostname']}} {{ hostvars[node]['control_if']['ipaddr']  }}:8080 check inter 1s
 {% endfor %}
 
-#frontend vip-scaleio-int
-#    bind {{ scaleio_vip }}:8443
-#    mode tcp
-#    default_backend scaleio
-#
-#backend scaleio
-#   mode tcp
-#  balance roundrobin
-#  stick-table type ip size 200k expire 30m
-#  stick on src
-#{% for node in groups['controller'] %}
-#    server {{ node }} {{ hostvars[node]['control_if']['ipaddr'] }}:8443 check inter 1s
-#{% endfor %}
+{% if scaleio_vip is defined%}
+frontend vip-scaleio-int
+    bind {{ scaleio_vip }}:8443
+    mode tcp
+    default_backend scaleio
+
+backend scaleio
+   mode tcp
+  balance roundrobin
+  stick-table type ip size 200k expire 30m
+  stick on src
+{% for node in groups['scaleio-mgmt'] %}
+    server {{ node }} {{ hostvars[node]['control_if']['ipaddr'] }}:8443 check inter 1s
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
uncommenting of the scaleio endpoint, and updates common task to fix issue with heterogenoeus systems, renamed tasks in kvm tasks to allow for easier reading


```
TASK [haproxy : install & configure HAproxy Kilo] ******************************
included: /root/dexter/dcaf/modules/rhel-osp/roles/haproxy/tasks/kilo.yml for haproxy-1, haproxy-2

TASK [haproxy : install haproxy] ***********************************************
ok: [haproxy-2] => (item=[u'haproxy', u'openstack-selinux'])
ok: [haproxy-1] => (item=[u'haproxy', u'openstack-selinux'])

TASK [haproxy : set sysctl] ****************************************************
ok: [haproxy-2]
ok: [haproxy-1]

TASK [haproxy : set rsyslog/haproxy.conf file] *********************************
ok: [haproxy-2]
ok: [haproxy-1]

TASK [haproxy : restart rsyslog] ***********************************************
changed: [haproxy-2]
changed: [haproxy-1]

TASK [haproxy : set haproxy.cfg file] ******************************************
changed: [haproxy-2]
changed: [haproxy-1]

TASK [haproxy : restart and disable haproxy] ***********************************
changed: [haproxy-2] => (item=haproxy)
changed: [haproxy-1] => (item=haproxy)

PLAY RECAP *********************************************************************
controller-1               : ok=1    changed=0    unreachable=0    failed=0
controller-2               : ok=1    changed=0    unreachable=0    failed=0
controller-3               : ok=1    changed=0    unreachable=0    failed=0
haproxy-1                  : ok=22   changed=5    unreachable=0    failed=0
haproxy-2                  : ok=22   changed=5    unreachable=0    failed=0
```