### PR TITLE
bare-metal-os remove scaleio

### DIFF
--- a/modules/bare-metal-os/README.md
+++ b/modules/bare-metal-os/README.md
@@ -1,13 +1,26 @@
 # CSC DCAF Bare Metal OS Deployment Automation
 
-This project deploys RHEL 7 to bare metal nodes using Hanlon and Ansible.
+The Bare-Metal_OS module is an automated deployment of an operating system on
+bare-metal hardware using Hanlon, currently the Red Hat Enterprise Linux OS. Though
+it is an automated process there are a few things tha need to be in place before
+you begin.
 
-* Create an inventory CSV file using inventory/example_inventory.csv as an
-example
-* Update inventory/group_vars/all.yml as needed
-* Run ansible-playbook site_inventory.yml to create the Ansible Inventory
-* Run ansible-playbook site_inventory.yml a second time to make sure the SMBIOS
-UUIDs are updated in the host_vars files
-* Run ansible-playbook site_reset.yml to ensure the hosts are discovered and
-ready for deployment
-* Run ansible-playbook site_deploy.yml to deploy RHEL
+## Before You Begin
+
+* Create the /opt/autodeploy/projects/inventory/hosts.ini file to include each
+  host being deployed to.
+* Create the /opt/autodeploy/projects/inventory/host_vars/host_name.yml file for 
+  each host being deployed to.
+* Create the /opt/autodeploy/projects/inventory/group_vars/bare-metal-os.yml file
+  with the appropriate values for the deployment.
+  
+Refer to the CSC DCAF Documentation for more details and what is included in these
+files.
+
+## Run the Bare-Metal_OS Automation
+
+Now that the inventory and variables have been created the automation can be used.
+
+* Run the site_reset.yml playbook to ensure the hosts are discovered and ready for
+  deployment.
+* Run the site_deploy.yml playbook to deploy the RHEL OS.

--- a/modules/bare-metal-os/inventory/group_vars/bare-metal-os.yml
+++ b/modules/bare-metal-os/inventory/group_vars/bare-metal-os.yml
@@ -38,47 +38,6 @@ site_password: localpassword
 ipmi_username: root
 ipmi_password: localpassword
 
-# ScaleIO Variables
-scaleio_license:
-scaleio_mgmt_interface: em3
-scaleio_interface: "bond0.{{ storage_public_vlan }}"
-scaleio_base_package_name: EMC-ScaleIO
-scaleio_version: 1.32-2451.4
-scaleio_protection_domain: pd1
-scaleio_cluster_mode: true
-scaleio_cluster_name: cluster1
-scaleio_password: Cluster1!
-scaleio_gateway_admin_password: 'Cluster1!'
-scaleio_lia_token: 'Cluster1!'
-scaleio_storage_pool: default
-
-scaleio_gateway_port: 8081
-scaleio_gateway_ssl_port: 8443
-
-scaleio_callhome_config:
-    - { section: 'general', option: 'email_from', value: 'from@somewhere.com' }
-    - { section: 'general', option: 'username', value: '' }
-    - { section: 'general', option: 'password', value: '' }
-    - { section: 'general', option: 'customer_name', value: 'somewhere' }
-    - { section: 'smtp', option: 'host', value: '127.0.0.1' }
-    - { section: 'smtp', option: 'username', value: '' }
-    - { section: 'smtp', option: 'password', value: '' }
-    - { section: 'email_alert', option: 'email_to', value: 'to@somewhere.com' }
-    - { section: 'email_alert', option: 'severity', value: '' }
-
-
-scaleio_mdm_primary_ip: "{{ hostvars[groups['mdm'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
-scaleio_mdm_primary_mgmt_ip: "{{ hostvars[groups['mdm'][0]]['ansible_'+scaleio_mgmt_interface]['ipv4']['address'] }}"
-
-scaleio_mdm_secondary_ip: "{{ hostvars[groups['mdm'][1]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
-scaleio_mdm_secondary_mgmt_ip: "{{ hostvars[groups['mdm'][1]]['ansible_'+scaleio_mgmt_interface]['ipv4']['address'] }}"
-
-# This IP address is either a single system or a VIP for HAproxy e.g. in OpenStack
-# Generally set to the scaleio_vip as defined in the Slimer project
-scaleio_gateway_ip: x.x.x.x
-#
-scaleio_tb_ip: "{{ hostvars[groups['tb'][0]]['ansible_'+scaleio_interface]['ipv4']['address'] }}"
-
 #Slimer Variables
 mtu: 8964
 # subscription manager vars:

--- a/modules/bare-metal-os/site.yml
+++ b/modules/bare-metal-os/site.yml
@@ -1,5 +1,0 @@
----
-
-- include: site_deploy.yml
-- include: ../slimer/site.yml
-- include: ../ansible-scaleio/site.yml

--- a/modules/bare-metal-os/site_deploy.yml
+++ b/modules/bare-metal-os/site_deploy.yml
@@ -1,4 +1,5 @@
 ---
+# This playbook will prepare Hanlon and the nodes for a bare-metal deployment.
 
 - name: Configure Hanlon with RHEL image, model and policies
   hosts: auto-deploy-node

--- a/modules/bare-metal-os/site_reset.yml
+++ b/modules/bare-metal-os/site_reset.yml
@@ -1,4 +1,5 @@
 ---
+# This playbook will prepare the hosts with Hanlon for deployment.
 
 - name: Rediscover nodes
   hosts: deploy


### PR DESCRIPTION
This PR is removing scaleio from bare-metal-os.

The ansible-scaleio project will be called from slimer if needed.

There are additional PRs.