### PR TITLE
Adding Demo support

### DIFF
--- a/modules/rhel-osp/demo.yml
+++ b/modules/rhel-osp/demo.yml
@@ -1,0 +1,6 @@
+---
+- name: Controller Demo Configuration
+  hosts: controller
+  roles:
+    - { role: demo, when: run_demo }
+

--- a/modules/rhel-osp/roles/demo/defaults/main.yml
+++ b/modules/rhel-osp/roles/demo/defaults/main.yml
@@ -1,0 +1,19 @@
+#keystone_auth_protocol: http
+#keystone_auth_port: 35357
+admin_user: admin
+admin_tenant: admin
+demo_user: admin
+demo_tenant: demo
+ext_net_name: external
+int_net_name: internal_net
+router_name: demo_router-1
+copy_image: True
+image_name: cirros-0.3.4-x86_64-disk.img
+image_disk_format: qcow2
+image_short_name: cirros
+image_root_password: "cubswin:)"
+
+#boot options
+nova_boot_flavor: m1.tiny
+nova_boot_name: test_vm
+

--- a/modules/rhel-osp/roles/demo/tasks/image.yml
+++ b/modules/rhel-osp/roles/demo/tasks/image.yml
@@ -1,0 +1,33 @@
+---
+- name: copy image to controller1
+  get_url:
+    url:  http://download.cirros-cloud.net/0.3.4/{{image_name}}
+    dest: /root/{{image_name}}
+  tags: demo
+  run_once: true
+
+- name: add image to glance
+  command: >
+    glance {{os_admin_auth}} image-create
+    --name {{image_short_name}}
+    --file /root/{{image_name}}
+    --disk-format {{image_disk_format}}
+    --container-format bare
+    --is-public true
+  run_once: true
+  tags: demo
+
+- name: copy cloud-init demo
+  template: src=cloud_cfg_demo.txt.j2 dest=/root/cloud_cfg_demo.txt
+  tags: demo
+
+- name: launch an instance
+  command: >
+    nova {{os_demo_auth}} boot
+    --flavor {{nova_boot_flavor}}
+    {{nova_boot_name}}
+    --user-data /root/cloud_cfg_demo.txt
+    --security-groups ssh-icmp
+    --image {{image_short_name}}
+  run_once: true
+  tags: demo

--- a/modules/rhel-osp/roles/demo/tasks/main.yml
+++ b/modules/rhel-osp/roles/demo/tasks/main.yml
@@ -1,0 +1,187 @@
+---
+# setups up test network for demo
+- name: deploy the keystonerc_demo file
+  template: src=keystonerc_demo.j2
+            dest=/root/keystonerc_demo
+            mode=0750 owner=root group=root
+  tags: demo
+
+- name: create demo project
+  keystone_user:
+    login_password: "{{admin_pass}}"
+    endpoint: "{{keystone_adminurl}}"
+    login_user: "{{admin_user}}"
+    login_tenant_name: "{{admin_tenant}}"
+    tenant: "{{demo_tenant}}"
+    tenant_description: "demo tenant"
+  run_once: true
+  tags: demo
+
+- name: add admin to demo tenant
+  keystone_user:
+    login_password: "{{admin_pass}}"
+    endpoint: "{{keystone_adminurl}}"
+    login_user: "{{admin_user}}"
+    login_tenant_name: "{{admin_tenant}}"
+    tenant: "{{demo_tenant}}"
+    user: "{{demo_user}}"
+    role: "_member_"
+  run_once: true
+  tags: demo
+
+- name: create demo user
+  keystone_user:
+    login_password: "{{admin_pass}}"
+    endpoint: "{{keystone_adminurl}}"
+    login_user: "{{admin_user}}"
+    login_tenant_name: "{{admin_tenant}}"
+    user: "{{demo_user}}"
+    password: "{{demo_pass}}"
+    tenant: "{{demo_tenant}}"
+    role: "_member_"
+  run_once: true
+  tags: demo
+
+- name: check for external network
+  command: neutron {{os_admin_auth}} net-list
+  register: cmd
+  run_once: true
+  tags: demo
+
+
+- name: create External Network.
+  command: >
+    neutron {{os_admin_auth}}
+    net-create {{ext_net_name}}
+    --router:external=True
+  run_once: true
+  when: "'{{ext_net_name}}' not in cmd.stdout"
+  tags: demo
+
+- name: create external Subnet.
+  command: >
+    neutron
+    {{os_admin_auth}}
+    subnet-create 
+    --gateway {{ext_gateway}}
+    --allocation-pool start={{start_ext_allocation}},end={{end_ext_allocation}}
+    --disable-dhcp
+    {{ext_net_name}}
+    {{demo_ext_network}}
+  when: '"{{demo_ext_network}}" not in cmd.stdout'
+  run_once: true
+  tags: demo
+
+- name: get external network ID
+  shell: neutron {{os_admin_auth}}  net-list | grep {{ext_net_name}} | gawk -F' ' '{print $2}'
+  register: external_id
+  run_once: true
+  tags: demo
+
+
+- name: create internal Network.
+  command: >
+    neutron
+    {{os_demo_auth}}
+    net-create {{int_net_name}}
+  when: '"{{int_net_name}}" not in cmd.stdout'
+  run_once: true
+  tags: demo
+
+- name: create internal Subnet.
+  command: >
+    neutron
+    {{os_demo_auth}}
+    subnet-create
+    {{int_net_name}} {{demo_int_network}}
+  run_once: true
+  when: '"{{demo_int_network}}" not in cmd.stdout'
+  tags: demo
+
+- name: get internal network ID
+  shell: neutron {{os_demo_auth}} net-list | grep {{int_net_name}} | gawk -F" " ' {print $6} '
+  register: internal_id
+  run_once: true
+  tags: demo
+
+- name: check for router
+  command: neutron {{os_demo_auth}} router-list
+  run_once: true
+  register: cmd
+  tags: demo
+
+- name: create router
+  command: >
+    neutron
+    {{os_demo_auth}}
+    router-create {{router_name}}
+  when: '"{{router_name}}" not in cmd.stdout'
+  run_once: true
+  tags: demo
+
+
+- name: check to see if gateway is set
+  command: neutron {{os_demo_auth}} router-show {{router_name}}
+  register: cmd
+  tags: demo
+  run_once: true
+
+- name: set router-gateway
+  command: neutron {{os_demo_auth}} router-gateway-set {{router_name}} {{external_id.stdout}}
+  run_once: true
+  when: '"{{external_id.stdout}}" not in cmd.stdout'
+  tags: demo
+
+- name: check to see if interface is added
+  command: neutron {{os_demo_auth}} router-port-list {{router_name}}
+  run_once: true
+  register: cmd
+  tags: demo
+
+- name: set internal router inteface in demo
+  command: neutron {{os_demo_auth}} router-interface-add {{router_name}} {{internal_id.stdout}}
+  run_once: true
+  when: '"{{internal_id.stdout}}" not in cmd.stdout'
+  tags: demo
+
+### create security group
+- name: get tenant ID for demo
+  shell: keystone {{os_admin_auth}} tenant-list | grep {{demo_tenant}} | gawk -F' ' '{print $2}'
+  register: tenant_id
+  run_once: true
+  tags: demo
+
+- name: create security group
+  shell: neutron {{os_demo_auth}} security-group-create ssh-icmp --description "ssh and icmp allowed" --tenant_id {{tenant_id.stdout}}| grep "| id " | gawk -F' ' '{print $4}'
+  run_once: true
+  register: sec_uuid
+  tags: demo
+
+
+
+- name: create ssh inbound rule
+  command: >
+    neutron {{os_demo_auth}}
+    security-group-rule-create
+    --direction ingress
+    --protocol tcp
+    --port-range-min 22
+    --port-range-max 22
+    {{ sec_uuid.stdout }}
+  run_once: true
+  tags: demo
+
+- name: create ssh inbound rule
+  command: >
+    neutron {{os_demo_auth}}
+    security-group-rule-create
+    --direction ingress
+    --protocol icmp
+    {{ sec_uuid.stdout }}
+  run_once: true
+  tags: demo
+
+- name: start image task
+  include: image.yml
+  when: copy_image
+  tags: demo

--- a/modules/rhel-osp/roles/demo/templates/cloud_cfg_demo.txt.j2
+++ b/modules/rhel-osp/roles/demo/templates/cloud_cfg_demo.txt.j2
@@ -1,0 +1,14 @@
+#cloud-config
+#vim:syntax=yaml
+debug: True
+ssh_pwauth: True
+disable_root: false
+chpasswd:
+  list: |
+    root: {{image_root_password}}
+    centos: centOS
+    cloud-user: cloud
+  expire: false
+runcmd:
+- sed -i'.orig' -e's/without-password/yes/' /etc/ssh/sshd_config
+- service sshd restart

--- a/modules/rhel-osp/roles/demo/templates/keystonerc_demo.j2
+++ b/modules/rhel-osp/roles/demo/templates/keystonerc_demo.j2
@@ -1,0 +1,7 @@
+export OS_USERNAME={{demo_user}}
+export OS_TENANT_NAME={{demo_tenant}}
+export OS_PROJECT_NAME={{demo_tenant}}
+export OS_REGION_NAME={{region | default("regionOne")}}
+export OS_PASSWORD={{ demo_pass }}
+export OS_AUTH_URL=http://{{ keystone_vip }}:35357/v2.0/
+export PS1='[\u@\h \W(keystone_demo)]\$ '

--- a/modules/rhel-osp/roles/demo/vars/main.yml
+++ b/modules/rhel-osp/roles/demo/vars/main.yml
@@ -1,0 +1,14 @@
+keystone_adminurl: "{{ keystone_auth_protocol|default('http') }}://{{ keystone_vip }}:{{ keystone_auth_port | default('35357') }}/v2.0"
+os_admin_auth: "--os-auth-url {{ keystone_adminurl}} --os-tenant-name {{admin_tenant}} --os-username {{admin_user }}  --os-password {{admin_pass}}"
+os_demo_auth: "--os-auth-url {{ keystone_adminurl}} --os-tenant-name {{demo_tenant}} --os-username {{demo_user }}  --os-password {{admin_pass}}"
+ext_gateway: "{{demo_ext_network | ipaddr('net') | ipaddr('1') | ipaddr('address')}}"
+start_ext_allocation: "{{demo_ext_network | ipaddr('net') | ipaddr('100') | ipaddr('address')}}"
+end_ext_allocation: "{{demo_ext_network | ipaddr('net') | ipaddr('200') | ipaddr('address')}}"
+
+
+credentials_dir: /var/lib/ansible
+#openstack service user passwords
+admin_pass: "{{ lookup('password', credentials_dir + '/credentials/admin_pass chars=ascii_letters,digits') }}"
+demo_pass: "{{ lookup('password', credentials_dir + '/credentials/admin_pass chars=ascii_letters,digits') }}"
+
+keystone_vip: "{{haproxy_vip}}"


### PR DESCRIPTION
In this PR, add a play and role, that creates a demo tenant, a demo user role for that tenant.  Creates and external network, router, security group, internal network within demo tenant.  
Downloads Cirros test image, and launches a test instance.

```
TASK [demo : launch an instance] ***********************************************
changed: [controller-1]

PLAY RECAP *********************************************************************
controller-1               : ok=27   changed=24   unreachable=0    failed=0
controller-2               : ok=4    changed=2    unreachable=0    failed=0
controller-3               : ok=4    changed=2    unreachable=0    failed=0

-----

[root@controller-1 ~]# . keystonerc_
-bash: keystonerc_: No such file or directory
[root@controller-1 ~]# . keystonerc_demo
[root@controller-1 ~(keystone_demo)]# nova list
+--------------------------------------+---------+--------+------------+-------------+----------------------------+
| ID                                   | Name    | Status | Task State | Power State | Networks                   |
+--------------------------------------+---------+--------+------------+-------------+----------------------------+
| e9c7c9d4-179f-43ab-ad6b-c23a236de51b | test_vm | ACTIVE | -          | Running     | internal_net=192.168.101.5 |
+--------------------------------------+---------+--------+------------+-------------+----------------------------+
```