### PR TITLE
fix bug that causes DNS to fail after restarting KVM host

### DIFF
--- a/modules/kvm-host/roles/ovs/tasks/main.yml
+++ b/modules/kvm-host/roles/ovs/tasks/main.yml
@@ -19,6 +19,14 @@
   tags:
     - mgmt_bridge
 
+- name: add DNS lines to ifcfg-br0
+  lineinfile:
+    dest: /etc/sysconfig/network-scripts/ifcfg-br0
+    regexp: '^DNS1'
+    line: 'DNS1={{dns1}}'
+  tags:
+    - mgmt_bridge
+    
 - name: remove HW address from ifcfg-br0
   lineinfile:
     dest: /etc/sysconfig/network-scripts/ifcfg-br0


### PR DESCRIPTION
This PR updates the kvmhost module so that the DNS name is correctly added to BR0 when it is created.  This lack of this was causing the DNS resolution to fail if the KVM_controller was restarted.

```
2016-04-19 16:09:27,862 p=36774 u=root |  TASK [ovs : add DNS lines to ifcfg-br0] ****************************************
2016-04-19 16:09:27,969 p=36774 u=root |  ok: [kvm_controller-2]
2016-04-19 16:09:27,973 p=36774 u=root |  ok: [kvm_controller-3]
2016-04-19 16:09:28,028 p=36774 u=root |  ok: [kvm_controller-1]
```

```
2016-04-15 12:34:51,113 p=803 u=root |  TASK [resize guest filesystem] *************************************************
2016-04-15 12:34:51,432 p=803 u=root |  changed: [controller-3]
2016-04-15 12:34:51,455 p=803 u=root |  changed: [swift-3]
2016-04-15 12:34:51,456 p=803 u=root |  changed: [network-3]
2016-04-15 12:34:51,892 p=803 u=root |  changed: [haproxy-2]
2016-04-15 12:34:51,940 p=803 u=root |  changed: [swift-2]
2016-04-15 12:34:52,010 p=803 u=root |  changed: [swift-1]
2016-04-15 12:34:52,040 p=803 u=root |  changed: [network-2]
2016-04-15 12:34:52,041 p=803 u=root |  changed: [controller-2]
2016-04-15 12:34:52,103 p=803 u=root |  changed: [controller-1]
2016-04-15 12:34:52,117 p=803 u=root |  changed: [network-1]
2016-04-15 12:34:52,167 p=803 u=root |  changed: [haproxy-1]
2016-04-15 12:34:52,172 p=803 u=root |  PLAY RECAP *********************************************************************
2016-04-15 12:34:52,172 p=803 u=root |  auto-deploy-node           : ok=7    changed=3    unreachable=0    failed=0
2016-04-15 12:34:52,172 p=803 u=root |  basevm                     : ok=10   changed=6    unreachable=0    failed=0
2016-04-15 12:34:52,172 p=803 u=root |  controller-1               : ok=16   changed=12   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  controller-2               : ok=15   changed=12   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  controller-3               : ok=15   changed=12   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  haproxy-1                  : ok=13   changed=10   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  haproxy-2                  : ok=13   changed=10   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  kvm_controller-1           : ok=43   changed=32   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  kvm_controller-2           : ok=31   changed=26   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  kvm_controller-3           : ok=31   changed=26   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  network-1                  : ok=15   changed=12   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  network-2                  : ok=15   changed=12   unreachable=0    failed=0
2016-04-15 12:34:52,173 p=803 u=root |  network-3                  : ok=15   changed=12   unreachable=0    failed=0
2016-04-15 12:34:52,174 p=803 u=root |  swift-1                    : ok=14   changed=11   unreachable=0    failed=0
2016-04-15 12:34:52,174 p=803 u=root |  swift-2                    : ok=14   changed=11   unreachable=0    failed=0
2016-04-15 12:34:52,174 p=803 u=root |  swift-3                    : ok=14   changed=11   unreachable=0    failed=0
```
