### PR TITLE
Correcting doc syntax and formatting

### DIFF
--- a/docsite/source/autodeploynode_module.rst
+++ b/docsite/source/autodeploynode_module.rst
@@ -211,15 +211,15 @@ the following variables in the ``inventory/group_vars/all.yml`` file.
 
 .. code-block:: yaml
 
-   # Required User Variables
-   rhn_user:
-   rhn_pass:
+    # Required User Variables
+    rhn_user:
+    rhn_pass:
 
 Run the stage_resources.yml playbook:
 
 .. code-block:: bash
 
-   ansible-playbook stage_resources.yml
+    ansible-playbook stage_resources.yml
 
 Configure DCAF Base variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -236,20 +236,19 @@ By default, the DHCP server will be installed with the following configuration:
 
 .. code-block:: yaml
 
-   dns1: 8.8.8.8
-   dhcp_start: 20
-   dhcp_end: 60
+    dns1: 8.8.8.8
+    dhcp_start: 20
+    dhcp_end: 60
 
 .. note::
 
-  The DHCP start and end values above are the last octet of the subnet the server
-  is installed in. For example,
+    The DHCP start and end values above are the last octet of the subnet the server
+    is installed in. For example,
+    172.17.16.20 would be ``dhcp_start: 20``
+    172.17.16.60 would be ``dhcp_end: 60``
 
-  172.17.16.20 would be ``dhcp_start: 20``
-  172.17.16.60 would be ``dhcp_end: 60``
-
-  To use alternate values, edit the ``dcaf/modules/autodeploynode/roles/dhcp-server/defaults.yml``
-  file with your own values.
+To use alternate values, edit the ``dcaf/modules/autodeploynode/roles/dhcp-server/defaults.yml``
+file with your own values.
 
 Running the Autodeploynode Playbook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -262,15 +261,15 @@ Now that the variables have been configured, run the following playbooks to fini
 
 .. note::
 
-  The ``main.yml`` playbook will also run the ``site_docker.yml`` and ``site_discovery.yml``
-  playbooks.
+    The ``main.yml`` playbook will also run the ``site_docker.yml`` and ``site_discovery.yml``
+    playbooks.
 
-  The ``site_docker.yml`` playbook will start the Hanlon Docker environment. First
-  it will clean up any existing containers. Then it will start the Mongo, Hanlon
-  Server and TFTP Server containers.
+    The ``site_docker.yml`` playbook will start the Hanlon Docker environment. First
+    it will clean up any existing containers. Then it will start the Mongo, Hanlon
+    Server and TFTP Server containers.
 
-  The ``site_discovery.yml`` playbook will configure the DHCP service and prepare
-  the Hanlon Server for the bare metal OS deployment.
+    The ``site_discovery.yml`` playbook will configure the DHCP service and prepare
+    the Hanlon Server for the bare metal OS deployment.
 
 At this point the AutoDeployNode has been configured and is ready to start using
 for automation.

--- a/docsite/source/bare_metal_os_module.rst
+++ b/docsite/source/bare_metal_os_module.rst
@@ -82,10 +82,10 @@ this file will vary depending on the what automation is being used.
 
 .. note::
 
-  The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
-  a module or the role the host will have within the module. Each :code:`[group]` name
-  should match the corresponding ``inventory/group_vars/group_name.yml`` group variable
-  file if it has one. All hosts listed should be under a :code:`[group]` heading.
+    The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
+    a module or the role the host will have within the module. Each :code:`[group]` name
+    should match the corresponding ``inventory/group_vars/group_name.yml`` group variable
+    file if it has one. All hosts listed should be under a :code:`[group]` heading.
 
 - **hosts.ini** - Copy the ``/opt/autodeploy/projects/dcaf/modules/bare-metal-os/inventory/host_vars/host.ini`` file to the ``/opt/autodeploy/projects/inventory/`` folder. Edit it to
   reflect the number of hosts and correct host names for the  deployment. This file
@@ -115,9 +115,9 @@ The ``bare-metal-os/inventory/hosts.ini`` file contains the following:
 
 .. note::
 
-  Do not modify a group of groups :code:`[group:children]`. These groups are defined
-  by the module. Add the required hosts in the respective :code:`[group]` section
-  as needed.
+    Do not modify a group of groups :code:`[group:children]`. These groups are defined
+    by the module. Add the required hosts in the respective :code:`[group]` section
+    as needed.
 
 Modify Host & Module Variables
 ------------------------------
@@ -159,12 +159,12 @@ Below is the example ``host_name.yml``
 
 .. note::
 
-  Each ``host_name.yml`` file must include the host hardware :code:`smbios-uuid`.
-  This can be found using the hosts vendor management tools. Refer to the vendor
-  documentation for more information.
+    Each ``host_name.yml`` file must include the host hardware :code:`smbios-uuid`.
+    This can be found using the hosts vendor management tools. Refer to the vendor
+    documentation for more information.
 
-  The ``smbios-uuid`` is unique and specific to the hardware so it must be different
-  in each ``host_name.yml`` file.
+    The ``smbios-uuid`` is unique and specific to the hardware so it must be different
+    in each ``host_name.yml`` file.
 
 group_vars
 ~~~~~~~~~~

--- a/docsite/source/index.rst
+++ b/docsite/source/index.rst
@@ -16,5 +16,6 @@ Contents:
     requirements
     autodeploynode_module
     bare_metal_os_module
+    kvm_host_module
     rhel_osp_module
     known_issues

--- a/docsite/source/kvm_host_module.rst
+++ b/docsite/source/kvm_host_module.rst
@@ -71,13 +71,13 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  The ``kvm-host/inventory/hosts.ini`` file contains many :code:`[group]` sections
-  with hosts and :code:`[group:children]` sections with groups as an example. Only
-  modify the :code:`[group]` of hosts as needed.
+    The ``kvm-host/inventory/hosts.ini`` file contains many :code:`[group]` sections
+    with hosts and :code:`[group:children]` sections with groups as an example. Only
+    modify the :code:`[group]` of hosts as needed.
 
 .. code-block:: yaml
 
-  Example:
+    Example:
     # ------------------------------------------------------------------
     # Do not modify a [group:children] section, they are module specific
     # ------------------------------------------------------------------
@@ -108,9 +108,9 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  Do not modify a group of groups :code:`[group:children]`. These groups are defined
-  by the module. Add the required hosts in the respective :code:`[group]` section
-  as needed.
+    Do not modify a group of groups :code:`[group:children]`. These groups are defined
+    by the module. Add the required hosts in the respective :code:`[group]` section
+    as needed.
 
 Modify Host & Project Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -143,9 +143,10 @@ one for ``hostname-1``.
           example_vm.yml
 
 .. note::
-The KVM-Host module has two types of `hosts`, one is the physical host (kvm-host)
-  and the virtual host (vm). Copy, rename and modify the appropriate type of example
-  host file as needed.
+
+    The KVM-Host module has two types of `hosts`, one is the physical host (kvm-host)
+    and the virtual host (vm). Copy, rename and modify the appropriate type of example
+    host file as needed.
 
 Below is the ``example_kvmhost.yml``
 
@@ -220,7 +221,7 @@ configured a certain way. Role specific variables are stored in the ``/roles/som
 and ``/roles/some_role/vars`` folders. Typically only the ``/roles/some_roles/defaults``
 would need to be modified. Always review both sets of variables for comtent.
 
-.. code-block:: bash
+.. code-block:: none
 
     /kvm-host/roles/some_role
     -- /defaults

--- a/docsite/source/overview.rst
+++ b/docsite/source/overview.rst
@@ -33,15 +33,15 @@ Ansible Inventory
 The inventory for CSC DCAF is located in the ``/opt/autodeploy/projects/inventory``
 folder. It follows the Ansible inventory hierarchy:
 
-.. code-block:: yaml
+.. code-block:: none
 
-  /inventory
-  -- /group_vars
-        all.yml
-        group_name.yml
-  -- hosts.ini
-  -- /host_vars
-        host_name.yml
+    /inventory
+    -- /group_vars
+          all.yml
+          group_name.yml
+    -- hosts.ini
+    -- /host_vars
+          host_name.yml
 
 - **hosts.ini** - The inventory file that contains the names of the hosts Ansible
   will execute against. Hosts can be grouped by adding a :code:`[group]` section
@@ -52,16 +52,16 @@ folder. It follows the Ansible inventory hierarchy:
 
 .. code-block:: yaml
 
-  [groups:children]
-  group1
-  group2
+    [groups:children]
+    group1
+    group2
 
-  [group1]
-  host1
-  host2
+    [group1]
+    host1
+    host2
 
-  [group2]
-  host3
+    [group2]
+    host3
 
   - **host_name.yml** - There should be a ``host_name.yml`` file for each host in the
   ``hosts.ini`` file. This file will contain variables that will be assigned to the

--- a/docsite/source/quickstart_ansible_scaleio.rst
+++ b/docsite/source/quickstart_ansible_scaleio.rst
@@ -52,23 +52,23 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
-  EMC ScaleIO roles. Each :code:`[group]` heading will contain a host or a child
-  ``group`` of hosts. If editing this file append to it and ensure there is no
-  duplication. All hosts listed should be under a :code:`[group]` heading.
+    The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
+    EMC ScaleIO roles. Each :code:`[group]` heading will contain a host or a child
+    ``group`` of hosts. If editing this file append to it and ensure there is no
+    duplication. All hosts listed should be under a :code:`[group]` heading.
 
 .. code-block:: yaml
 
-  Example:
-  # Host(s) with the MDM role
-  [mdm]
-  host-1
-  ...
+    Example:
+    # Host(s) with the MDM role
+    [mdm]
+    host-1
+    ...
 
-  # Host(s) with the TB role
-  [tb]
-  host-2
-  ...
+    # Host(s) with the TB role
+    [tb]
+    host-2
+    ...
 
 Modify Host & Project Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docsite/source/quickstart_bare_metal_os.rst
+++ b/docsite/source/quickstart_bare_metal_os.rst
@@ -69,11 +69,11 @@ and examples of this file refer to the CSC DCAF project documentation.
 
 .. note::
 
-  The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
-  a module or the role the host will have within the module. Each :code:`[group]` name
-  should match the corresponding ``inventory/group_vars/group_name.yml`` group variable
-  file. If editing this file append to it and ensure there is no duplication. All
-  hosts listed should be under a :code:`group` heading.
+    The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
+    a module or the role the host will have within the module. Each :code:`[group]` name
+    should match the corresponding ``inventory/group_vars/group_name.yml`` group variable
+    file. If editing this file append to it and ensure there is no duplication. All
+    hosts listed should be under a :code:`group` heading.
 
 .. code-block:: yaml
 
@@ -101,9 +101,9 @@ This module uses multiple variables that are managed in various files. The
 
 .. note::
 
-  Each ``host_name.yml`` file must include the host hardware :code:`smbios-uuid`.
-  This can be found using the hosts vendor management tools. Refer to the vendor
-  documentation for more information.
+    Each ``host_name.yml`` file must include the host hardware :code:`smbios-uuid`.
+    This can be found using the hosts vendor management tools. Refer to the vendor
+    documentation for more information.
 
 - **bare_metal_os.yml** - Copy the ``/opt/autodeploy/projects/dcaf/modules/bare-metal-os/inventory/group_vars/bare_metal_os.yml``
   file to the ``/opt/autodeploy/projects/inventory/group_vars/`` folder and modify

--- a/docsite/source/quickstart_kvm_host.rst
+++ b/docsite/source/quickstart_kvm_host.rst
@@ -37,24 +37,24 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
-  RHOSP and module roles. Each :code:`[group]` heading will contain a host or a child
-  ``group`` of hosts. If editing this file append to it and ensure there is no
-  duplication. All hosts listed should be under a :code:`[group]` heading.
+    The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
+    RHOSP and module roles. Each :code:`[group]` heading will contain a host or a child
+    ``group`` of hosts. If editing this file append to it and ensure there is no
+    duplication. All hosts listed should be under a :code:`[group]` heading.
 
 .. code-block:: yaml
 
-  Example:
-  # KVM host machine(s)
-  [kvmhosts]
-  kvm-controller-1
-  ...
+    Example:
+    # KVM host machine(s)
+    [kvmhosts]
+    kvm-controller-1
+    ...
 
-  # VM(s) to be created
-  [nodes]
-  controller-1
-  compute-1
-  ...
+    # VM(s) to be created
+    [nodes]
+    controller-1
+    compute-1
+    ...
 
 Modify Host & Project Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,9 +65,9 @@ This module uses multiple variables that are managed in various files. The
 
 .. note::
 
-  The KVM-Host module has two types of ``hosts``, one is the physical host ``(kvm-host)``
-  and the virtual host ``(vm)``. Copy, rename and modify the appropriate type of example
-  host file as needed.
+    The KVM-Host module has two types of ``hosts``, one is the physical host ``(kvm-host)``
+    and the virtual host ``(vm)``. Copy, rename and modify the appropriate type of example
+    host file as needed.
 
 - **host_name.yml** - There should be a ``/opt/autodeploy/projects/inventory/host_vars/host_name.yml``
   for each host, physical and virtual, in the hosts.ini file. Create or modify these

--- a/docsite/source/quickstart_rhel_osp.rst
+++ b/docsite/source/quickstart_rhel_osp.rst
@@ -41,23 +41,23 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
-  RHOSP roles. Each :code:`[group]` heading will contain a host or a child
-  ``group`` of hosts. If editing this file append to it and ensure there is no
-  duplication. All hosts listed should be under a :code:`[group]` heading.
+    The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
+    RHOSP roles. Each :code:`[group]` heading will contain a host or a child
+    ``group`` of hosts. If editing this file append to it and ensure there is no
+    duplication. All hosts listed should be under a :code:`[group]` heading.
 
 .. code-block:: yaml
 
-  Example:
-  # Host(s) with the Controller role
-  [controller]
-  controller1
-  ...
+    Example:
+    # Host(s) with the Controller role
+    [controller]
+    controller1
+    ...
 
-  # Host(s) with the Compute role
-  [compute]
-  compute1
-  ...
+    # Host(s) with the Compute role
+    [compute]
+    compute1
+    ...
 
 Modify Host & Project Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,9 +68,9 @@ This project uses multiple variables that are managed in various files. The
 
 .. note::
 
-  The RHEL-OSP module has multiple types of `hosts` based on the RHOSP role or
-  service. Copy, rename and modify the appropriate type of example host file as
-  needed.
+    The RHEL-OSP module has multiple types of `hosts` based on the RHOSP role or
+    service. Copy, rename and modify the appropriate type of example host file as
+    needed.
 
 - **host_name.yml** - There should be a ``/opt/autodeploy/projects/inventory/host_vars/host_name.yml``
   for each host, based on RHOSP role or service, in the hosts.ini file. Create or
@@ -79,8 +79,8 @@ This project uses multiple variables that are managed in various files. The
 
 .. note::
 
-  The RHEL-OSP module has multiple `group_name` variable files based on the RHOSP
-  role or service.
+    The RHEL-OSP module has multiple `group_name` variable files based on the RHOSP
+    role or service.
 
 - **group_name.yml** - Copy all of the ``/opt/autodeploy/projects/dcaf/rhel-osp/inventory/group_vars/group_name.yml``
   files to the ``/opt/autodeploy/projects/inventory/group_vars/`` folder and modify

--- a/docsite/source/quickstart_slimer.rst
+++ b/docsite/source/quickstart_slimer.rst
@@ -71,11 +71,11 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
-  a module or the role the host will have within the module. Each :code:`[group]`
-  name should match the corresponding ``inventory/group_vars/group_name.yml`` group
-  variable file. If editing this file append to it and ensure there is no duplication.
-  All hosts listed should be under a :code:`group` heading.
+    The ``hosts.ini`` will contain :code:`[group]` headings that correspond to
+    a module or the role the host will have within the module. Each :code:`[group]`
+    name should match the corresponding ``inventory/group_vars/group_name.yml`` group
+    variable file. If editing this file append to it and ensure there is no duplication.
+    All hosts listed should be under a :code:`group` heading.
 
 .. code-block:: yaml
 

--- a/docsite/source/rhel_osp_module.rst
+++ b/docsite/source/rhel_osp_module.rst
@@ -91,9 +91,9 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  The ``rhel-osp/inventory/hosts.ini`` file contains many :code:`[group]` sections
-  with hosts and :code:`[group:children]` sections with groups as an example. Only
-  modify the :code:`[group]` of hosts as needed.
+    The ``rhel-osp/inventory/hosts.ini`` file contains many :code:`[group]` sections
+    with hosts and :code:`[group:children]` sections with groups as an example. Only
+    modify the :code:`[group]` of hosts as needed.
 
 .. code-block:: bash
 
@@ -208,9 +208,9 @@ Edit the inventory to reflect your environment.
 
 .. note::
 
-  Do not modify a group of groups :code:`[group:children]`. These groups are defined
-  by the module. Add the required hosts in the respective :code:`[group]` section
-  as needed.
+    Do not modify a group of groups :code:`[group:children]`. These groups are defined
+    by the module. Add the required hosts in the respective :code:`[group]` section
+    as needed.
 
 
 Modify Host & Project Variables
@@ -247,9 +247,9 @@ one for ``hostname-1``.
 
 .. note::
 
-  The RHEL-OSP module has numerous types of ``hosts`` based on the RHOSP role or
-  service. Copy, rename and modify the appropriate type of example_host.yml file
-  as needed.
+    The RHEL-OSP module has numerous types of ``hosts`` based on the RHOSP role or
+    service. Copy, rename and modify the appropriate type of example_host.yml file
+    as needed.
 
 Below is the ``example-compute-host.yml``
 
@@ -284,7 +284,7 @@ Below is the ``example-compute-host.yml``
 
 .. note::
 
-  The ``host_name.yml`` file is being appended to. Check it for duplicate variables.
+    The ``host_name.yml`` file is being appended to. Check it for duplicate variables.
 
 group_vars
 ~~~~~~~~~~
@@ -345,26 +345,26 @@ Next run the ``rhel-osp/site.yml`` playbook to deploy RHEL OSP to the hosts in i
 
 .. note::
 
-  The ``site.yml`` playbook will call the following playbooks.
+    The ``site.yml`` playbook will call the following playbooks.
 
-  The ``haproxy.yml`` playbook will create firewall rules, install and configure
-  Keepalived and HAProxy.
+    The ``haproxy.yml`` playbook will create firewall rules, install and configure
+    Keepalived and HAProxy.
 
-  The ``control_plane.yml`` playbook will include a series of playbooks that will
-  install and configure the control plane services.
+    The ``control_plane.yml`` playbook will include a series of playbooks that will
+    install and configure the control plane services.
 
-  The ``neutron-network-node.yml`` playbook will install and configure the Neutron
-  networking on the grouped hosts. It will also set the required firewall rules
-  for Neutron.
+    The ``neutron-network-node.yml`` playbook will install and configure the Neutron
+    networking on the grouped hosts. It will also set the required firewall rules
+    for Neutron.
 
-  The ``compute_node.yml`` playbook will install and configure the required Nova
-  Compute packages, Neutron agents and create Nova firewall rules.
+    The ``compute_node.yml`` playbook will install and configure the required Nova
+    Compute packages, Neutron agents and create Nova firewall rules.
 
-  The ``swift.yml`` playbook will install and configure Swift and other required
-  agents. It will also create required firewall rules for these services.
+    The ``swift.yml`` playbook will install and configure Swift and other required
+    agents. It will also create required firewall rules for these services.
 
-  The ``prep-scaleio.yml`` playbook will create the required firewall rules for
-  use with EMC SCaleIO.
+    The ``prep-scaleio.yml`` playbook will create the required firewall rules for
+    use with EMC SCaleIO.
 
 
 At this point RHEL OSP has been installed and configured on all hosts listed


### PR DESCRIPTION
- Standardize indents for `code-block::` and `note::` at four spaces.
- Add kvm_host_module doc to index.
- Correct syntax highlighting styles

Testing docsite build:
```
> $ make html                                                                                                                  [±gh-pages ●●]
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v1.3.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 15 source files that are out of date
updating environment: 15 added, 0 changed, 0 removed
reading sources... [100%] rhel_osp_module
/Users/rteague/Development/dcaf/docsite/source/quickstart.rst:13: WARNING: toctree contains reference to nonexisting document u'quickstart_vmware'
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] rhel_osp_module
generating indices... genindex
writing additional pages... search
copying static files... WARNING: html_static_path entry u'/Users/rteague/Development/dcaf/docsite/source/_static' does not exist
done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 2 warnings.

Build finished. The HTML pages are in build/html.
```