### PR TITLE
Adding CentOS support

### DIFF
--- a/modules/autodeploynode/build.sh
+++ b/modules/autodeploynode/build.sh
@@ -3,6 +3,7 @@
 # DCAF AutoDeploy Node Installation
 # =================================
 # Prior to running this script, the following exports must be configured
+# when running on Red Hat Enterprise Linux
 # export RHN_USER="username"
 # export RHN_PASS="password"    # escape dollar signs (\$)
 # export RHN_POOL="pool_id"     # 32-char pool ID
@@ -10,13 +11,26 @@
 # Once these prerequisites are in place, the script can be executed by:
 # curl https://raw.githubusercontent.com/csc/dcaf/master/modules/autodeploynode/build.sh | bash
 
-# TODO Add error handling to exit if a command fails along the way
-set -eu -o pipefail
+set -e -o pipefail
 
-subscription-manager register --username=$RHN_USER  --password=$RHN_PASS
-subscription-manager attach --pool=$RHN_POOL
-subscription-manager repos --disable=*
-subscription-manager repos --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-openstack-6.0-rpms --enable=rhel-server-rhscl-7-rpms --enable=rhel-ha-for-rhel-7-server-rpms
+# Check for /etc/os-release
+if [ -f /etc/os-release ]; then
+    # Source the file
+    . /etc/os-release
+    # If we are running on RHEL
+    if [ "$NAME" == "Red Hat Enterprise Linux Server" ]; then
+        # Check for empty/undefined ENV variables
+        if [[ -z $RHN_USER || -z $RHN_PASS || -z $RHN_POOL ]]; then
+            echo "ERROR: Environment variables RHN_USER, RHN_PASS and RHN_POOL must be defined."
+            exit 1
+        else
+            subscription-manager register --username=$RHN_USER  --password=$RHN_PASS
+            subscription-manager attach --pool=$RHN_POOL
+            subscription-manager repos --disable=*
+            subscription-manager repos --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-openstack-6.0-rpms --enable=rhel-server-rhscl-7-rpms --enable=rhel-ha-for-rhel-7-server-rpms
+        fi
+    fi
+fi
 
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install git wget rpm-build make asciidoc python2-devel python-setuptools
@@ -31,6 +45,5 @@ cd ..
 
 wget https://raw.githubusercontent.com/csc/dcaf/master/modules/autodeploynode/initial_stage.yml
 ansible-playbook initial_stage.yml
-cd /opt/autodeploy/projects/dcaf/modules/autodeploynode
 
-ansible-playbook main.yml
+ansible-playbook /opt/autodeploy/projects/dcaf/modules/autodeploynode/main.yml

--- a/modules/autodeploynode/roles/base/files/pip-requirements.txt
+++ b/modules/autodeploynode/roles/base/files/pip-requirements.txt
@@ -2,6 +2,5 @@
 docker-py
 
 ## Other requirements
-pip2pi==0.6.8
-selenium==2.48.0
+selenium
 pyvmomi==5.5.0-2014.1.1

--- a/modules/autodeploynode/roles/base/tasks/main.yml
+++ b/modules/autodeploynode/roles/base/tasks/main.yml
@@ -59,6 +59,7 @@
     name: firewalld
     state: stopped
     enabled: no
+  when: ansible_distribution == 'Red Hat Enterprise Linux'
 
 - name: Create directories for hanlon
   file:


### PR DESCRIPTION
This PR adds support for running CentOS as the base OS for the autodeploynode.

- build.sh - Adding conditional distribution handling to only run `subscription-manage` for RHEL
- build.sh - Added `ERROR` message if `RHN_*` env variables are not set
- pip-requirements
  - Removed `pip2pi`, unneeded
  - Removed version from selenium, enables supporting newer versions of FireFox
- Added distribution check to firewalld task as this is not needed on CentOS

Testing:
Fresh build of autodeploynode and run of bare-metal-os for both CentOS-7 and RHEL-7.

