### PR TITLE
BUGFIX: Correcting distribution flag

### DIFF
--- a/modules/autodeploynode/roles/base/tasks/main.yml
+++ b/modules/autodeploynode/roles/base/tasks/main.yml
@@ -59,7 +59,7 @@
     name: firewalld
     state: stopped
     enabled: no
-  when: ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution == 'RedHat'
 
 - name: Create directories for hanlon
   file:


### PR DESCRIPTION
Matching distribution as reported by Ansible instead of /etc/os-release

Testing:
```
TASK [base : Disable firewalld] ************************************************
changed: [localhost]

TASK [base : Create directories for hanlon] ************************************
ok: [localhost] => (item=/opt/hanlon)
ok: [localhost] => (item=/opt/hanlon/image)
ok: [localhost] => (item=/opt/deploy)

TASK [base : Set the correct timezone] *****************************************
ok: [localhost]

TASK [base : Configure NTP] ****************************************************
ok: [localhost]

TASK [base : Copy the iptables config file] ************************************
ok: [localhost]

TASK [base : Start & enable iptables, ntpd & docker] ***************************
changed: [localhost] => (item=iptables)
changed: [localhost] => (item=ntpd)
changed: [localhost] => (item=docker)
```